### PR TITLE
Fix fan not starting after stopping

### DIFF
--- a/opifancontrol.sh
+++ b/opifancontrol.sh
@@ -121,7 +121,7 @@ while true; do
             TARGET_PWM=$CURRENT_PWM
         fi
 
-        if [ $TARGET_PWM -eq 0 ]; then
+        if [ $TARGET_PWM -eq 0 ] && [ $CURRENT_PWM -ne 0 ]; then
             # Wait for the ramp down delay before turning off the fan to avoid rapid on/off cycles
             sleep $RAMP_DOWN_DELAY_SECONDS
             LAST_RAMPED_DOWN_TS=$(date +%s)


### PR DESCRIPTION
Before the fix:
```
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Starting opifancontrol...
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: PWM range: 192
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: PWM clock: 4
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Fan GPIO pin: 2
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Temperature poll interval: 2 seconds
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Temperature thresholds (C): 45, 50, 60
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Fan speed thresholds (%): 50, 75, 100
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Ramp up delay: 15 seconds
Apr 06 14:10:24 orangepi5plus opifancontrol.sh[25384]: Ramp down delay: 60 seconds
Apr 06 14:11:35 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 45, target PWM: 96, current PWM: 0
Apr 06 14:12:37 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 42, target PWM: 0, current PWM: 96
Apr 06 14:13:39 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 46, target PWM: 0, current PWM: 0
Apr 06 14:14:43 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 49, target PWM: 0, current PWM: 0
Apr 06 14:15:45 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 51, target PWM: 0, current PWM: 0
Apr 06 14:16:47 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 53, target PWM: 0, current PWM: 0
Apr 06 14:17:49 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 50, target PWM: 0, current PWM: 0
Apr 06 14:18:51 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 54, target PWM: 0, current PWM: 0
Apr 06 14:19:53 orangepi5plus opifancontrol.sh[25384]: Changing Fan Speed | CPU temp: 49, target PWM: 0, current PWM: 0
```

After the fix:
```
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Starting opifancontrol...
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: PWM range: 192
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: PWM clock: 4
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Fan GPIO pin: 2
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Temperature poll interval: 2 seconds
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Temperature thresholds (C): 45, 50, 60
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Fan speed thresholds (%): 50, 75, 100
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Ramp up delay: 15 seconds
Apr 06 14:33:12 orangepi5plus opifancontrol.sh[27092]: Ramp down delay: 60 seconds
Apr 06 14:33:20 orangepi5plus opifancontrol.sh[27092]: Changing Fan Speed | CPU temp: 45, target PWM: 96, current PWM: 0
Apr 06 14:34:22 orangepi5plus opifancontrol.sh[27092]: Changing Fan Speed | CPU temp: 42, target PWM: 0, current PWM: 96
Apr 06 14:35:05 orangepi5plus opifancontrol.sh[27092]: Changing Fan Speed | CPU temp: 45, target PWM: 96, current PWM: 0
```